### PR TITLE
Cap on slippage

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "format": "prettier --write src/**/*.js"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/Actions.js
+++ b/src/Actions.js
@@ -1,6 +1,5 @@
-import { Droplet, Link, Repeat, Send } from "react-feather";
-
 import React from "react";
+import { Droplet, Link, Repeat, Send } from "react-feather";
 
 export default function Actions(props) {
   const { setShowModal, setShowPage } = props;

--- a/src/ApolloWrapper.js
+++ b/src/ApolloWrapper.js
@@ -1,5 +1,10 @@
-import { ApolloClient, InMemoryCache } from "@apollo/client";
+import { default as App } from "./App";
+import CurrentMinerContext from "./CurrentMinerContext";
+import HostContext from "./HostContext";
 import { BOOTNODES, PROD } from "./constants";
+import { ApolloClient, InMemoryCache } from "@apollo/client";
+import { ApolloProvider } from "@apollo/client";
+import { sample } from "lodash";
 import {
   default as React,
   useCallback,
@@ -7,12 +12,6 @@ import {
   useRef,
   useState,
 } from "react";
-
-import { ApolloProvider } from "@apollo/client";
-import { default as App } from "./App";
-import CurrentMinerContext from "./CurrentMinerContext";
-import HostContext from "./HostContext";
-import { sample } from "lodash";
 
 export default function ApolloWrapper() {
   const [host, setHost] = useState(sample(BOOTNODES));

--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,6 @@
-import { LIQUIDITY_TOKENS, TOKENS } from "./constants.js";
-import { default as React, useMemo, useState } from "react";
-import { animated, useTransition } from "react-spring";
-import {
-  useGetCurrentBlock,
-  useGetLiquidityTokens,
-  useGetTokens,
-} from "./queries";
-
 import Actions from "./Actions";
-import { BASE_FACTOR } from "./constants";
 import Balances from "./Balances";
 import Bridge from "./Bridge";
-import { Buffer } from "buffer/";
 import Exchange from "./Exchange";
 import Header from "./Header";
 import LiquidityBalances from "./LiquidityBalances";
@@ -22,11 +11,21 @@ import Send from "./Send";
 import Sidebar from "./Sidebar";
 import Total from "./Total";
 import YourAddress from "./YourAddress";
-import { compact } from "lodash";
-import { default as ethers } from "ethers";
-import nacl from "tweetnacl";
-import { sumBy } from "lodash";
+import { BASE_FACTOR } from "./constants";
+import { LIQUIDITY_TOKENS, TOKENS } from "./constants.js";
 import { useLocalStorage } from "./helpers";
+import {
+  useGetCurrentBlock,
+  useGetLiquidityTokens,
+  useGetTokens,
+} from "./queries";
+import { Buffer } from "buffer/";
+import { default as ethers } from "ethers";
+import { compact } from "lodash";
+import { sumBy } from "lodash";
+import { default as React, useMemo, useState } from "react";
+import { animated, useTransition } from "react-spring";
+import nacl from "tweetnacl";
 
 function App(props) {
   const { setHost } = props;

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import Total from "./Total";
 import YourAddress from "./YourAddress";
 import { BASE_FACTOR } from "./constants";
 import { LIQUIDITY_TOKENS, TOKENS } from "./constants.js";
-import { useLocalStorage } from "./helpers";
+import {useLocalStorage} from "./helpers";
 import {
   useGetCurrentBlock,
   useGetLiquidityTokens,

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,6 +1,6 @@
 import App from "./App";
-import React from "react";
 import { render } from "@testing-library/react";
+import React from "react";
 
 test("renders learn react link", () => {
   const { getByText } = render(<App />);

--- a/src/Balances.js
+++ b/src/Balances.js
@@ -1,6 +1,5 @@
-import { formatCurrency, formatTokenBalance, tokenName } from "./helpers";
-
 import { BASE_FACTOR } from "./constants";
+import { formatCurrency, formatTokenBalance, tokenName } from "./helpers";
 import { default as React } from "react";
 
 export default function Balances(props) {

--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -1,22 +1,21 @@
+import BridgeJSON from "./Bridge.json";
+import TokenSelect from "./Inputs/TokenSelect.js";
 import { ETH_BRIDGE_ADDRESS, WETH } from "./constants";
-
-import { ArrowDown } from "react-feather";
 import { BASE_FACTOR } from "./constants";
 import { BRIDGE_TOKENS } from "./constants";
-import BridgeJSON from "./Bridge.json";
-import Button from "react-bootstrap/Button";
-import { ChevronLeft } from "react-feather";
+import { parseUnits } from "./helpers";
+import { usePostTransaction } from "./mutations";
 import ERC20JSON from "@openzeppelin/contracts/build/contracts/ERC20";
-import Form from "react-bootstrap/Form";
+import { default as ethers } from "ethers";
+import { differenceBy } from "lodash";
 import { default as React } from "react";
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
 import Spinner from "react-bootstrap/Spinner";
 import Tab from "react-bootstrap/Tab";
 import Tabs from "react-bootstrap/Tabs";
-import TokenSelect from "./Inputs/TokenSelect.js";
-import { differenceBy } from "lodash";
-import { default as ethers } from "ethers";
-import { parseUnits } from "./helpers";
-import { usePostTransaction } from "./mutations";
+import { ArrowDown } from "react-feather";
+import { ChevronLeft } from "react-feather";
 
 const { MaxUint256 } = ethers.constants;
 const { hexlify, arrayify } = ethers.utils;

--- a/src/Exchange.js
+++ b/src/Exchange.js
@@ -281,7 +281,7 @@ export default function Exchange(props) {
           {error?<div id="error-message">
             <span className="text-danger"><strong>Error: {error}</strong></span>
           </div>:null}
-          {!!outputAmount && outputAmount > 0 && !!inputAmount && inputAmount > 0 ? <Button
+          {!!outputAmount && outputAmount > 0 && !!inputAmount && inputAmount > 0 && inputToken.ticker !== outputToken.ticker ? <Button
             type="submit"
             className="btn btn-lg btn-block btn-primary m-1"
             variant="contained"

--- a/src/Exchange.js
+++ b/src/Exchange.js
@@ -281,7 +281,7 @@ export default function Exchange(props) {
           {error?<div id="error-message">
             <span className="text-danger"><strong>Error: {error}</strong></span>
           </div>:null}
-          <Button
+          {!!outputAmount && outputAmount > 0 && !!inputAmount && inputAmount > 0 ? <Button
             type="submit"
             className="btn btn-lg btn-block btn-primary m-1"
             variant="contained"
@@ -289,6 +289,18 @@ export default function Exchange(props) {
           >
             Exchange
           </Button>
+          :
+          <Button
+            type="submit"
+            className="btn btn-lg btn-block btn-primary m-1"
+            variant="contained"
+            color="primary"
+            disabled
+          >
+            Exchange
+          </Button>
+          }
+
         </Form>
       </div>
     </>

--- a/src/Exchange.js
+++ b/src/Exchange.js
@@ -7,7 +7,7 @@ import {
   formatTokenExchangeRate,
 } from "./helpers";
 import { usePostTransaction } from "./mutations";
-import { BigInt, add, subtract, multiply, divide, equal } from "jsbi";
+import { BigInt, add, subtract, multiply, divide } from "jsbi";
 import { find } from "lodash";
 import { default as React, useMemo } from "react";
 import { Button, Form } from "react-bootstrap";
@@ -66,7 +66,7 @@ export default function Exchange(props) {
   const calculateAvailableQuantity = (inputLiquidityToken, outputLiquidityToken, outputTokenName) => {
     const quantity = outputTokenName === 'USD'
       ? inputLiquidityToken.totalSupply / inputLiquidityToken.price * BASE_FACTOR
-      : outputLiquidityToken.totalSupply;
+      : outputLiquidityToken.totalSupply / BASE_FACTOR;
 
     setAvailableQuantity(isNaN(quantity) ? new BigInt(0) : quantity);
   };
@@ -114,15 +114,14 @@ export default function Exchange(props) {
 
 
   React.useEffect(() => {
-    const token = find(liquidityTokens, ["id", inputToken.id]);
-    setInputLiquidityToken(token);
-    calculateAvailableQuantity(token, outputLiquidityToken, outputToken.name);
-  }, [inputToken, liquidityTokens]);
-  React.useEffect(() => {
-    const token = find(liquidityTokens, ["id", outputToken.id]);
-    setOutputLiquidityToken(token);
-    calculateAvailableQuantity(inputLiquidityToken, token, outputToken.name);
-  }, [outputToken, liquidityTokens]);
+    const _inputLiquidityToken = find(liquidityTokens, ["id", inputToken.id]);
+    setInputLiquidityToken(_inputLiquidityToken);
+
+    const _outputLiquidityToken = find(liquidityTokens, ["id", outputToken.id]);
+    setOutputLiquidityToken(_outputLiquidityToken);
+
+    calculateAvailableQuantity(inputLiquidityToken, outputLiquidityToken, outputToken.name);
+  }, [inputToken, outputToken, inputLiquidityToken, outputLiquidityToken, liquidityTokens]);
 
 
   const exchangeRate = useMemo(() => {
@@ -139,7 +138,7 @@ export default function Exchange(props) {
     } else {
       return null;
     }
-  }, [inputLiquidityToken, outputLiquidityToken]);
+  }, [inputToken, outputToken, inputLiquidityToken, outputLiquidityToken]);
 
   const outputAmount = useMemo(() => {
     if (!inputAmount || !inputLiquidityToken.totalSupply) {
@@ -250,7 +249,7 @@ export default function Exchange(props) {
           </Form.Group>
           <Form.Group className="basic">
             <Form.Label>Available Quantity</Form.Label>
-              <span>{formatTokenBalance(availableQuantity)}</span>
+              <span>{formatTokenBalance(availableQuantity * BASE_FACTOR)}</span>
           </Form.Group>
           <ul className="listview flush transparent simple-listview no-space mt-3">
             <li>

--- a/src/Header.js
+++ b/src/Header.js
@@ -1,10 +1,9 @@
-import { Menu, X } from "react-feather";
-
-import Identicon from "react-identicons";
-import Logo from "./logo.svg";
-import React from "react";
-import base64url from "base64url";
 import { useLocalStorage } from "./helpers";
+import Logo from "./logo.svg";
+import base64url from "base64url";
+import React from "react";
+import { Menu, X } from "react-feather";
+import Identicon from "react-identicons";
 
 export default function WalletMenu(props) {
   const { setShowSidebar, publicKey } = props;

--- a/src/HostContext.js
+++ b/src/HostContext.js
@@ -1,6 +1,6 @@
 import { BOOTNODES } from "./constants";
-import { createContext } from "react";
 import { sample } from "lodash";
+import { createContext } from "react";
 
 const HostContext = createContext([sample(BOOTNODES), () => {}]);
 

--- a/src/Inputs/TokenAmountInput.js
+++ b/src/Inputs/TokenAmountInput.js
@@ -7,11 +7,11 @@ export default function TokenAmountInput(props) {
   const { onChange, currency, value } = props;
   const [textValue, setTextValue] = useState(value || "");
   const handleOnChange = ({ target }) => {
-    console.log(`Received new target value ${target.value}`);
     let { groups } = /\$?(?<number>[\d,]*)?(?<decimal>\.\d{0,6})?/.exec(
       target.value
     );
     if (!groups.number & !groups.decimal) {
+      onChange(null);
       return setTextValue("");
     }
     const intValue = parseInt((groups.number || "0").replaceAll(",", ""));

--- a/src/Inputs/TokenAmountInput.js
+++ b/src/Inputs/TokenAmountInput.js
@@ -1,12 +1,13 @@
-import { default as React, useState } from "react";
-import { BigInt } from "jsbi";
 import { BASE_FACTOR } from "../constants";
+import { BigInt } from "jsbi";
+import { default as React, useState } from "react";
 import { Form } from "react-bootstrap";
+
 export default function TokenAmountInput(props) {
   const { onChange, currency, value } = props;
   const [textValue, setTextValue] = useState(value || "");
   const handleOnChange = ({ target }) => {
-    console.log(`Received new target value ${target.value}`)
+    console.log(`Received new target value ${target.value}`);
     let { groups } = /\$?(?<number>[\d,]*)?(?<decimal>\.\d{0,6})?/.exec(
       target.value
     );

--- a/src/Inputs/TokenAmountInput.js
+++ b/src/Inputs/TokenAmountInput.js
@@ -3,9 +3,10 @@ import { BigInt } from "jsbi";
 import { BASE_FACTOR } from "../constants";
 import { Form } from "react-bootstrap";
 export default function TokenAmountInput(props) {
-  const { onChange, currency } = props;
-  const [textValue, setTextValue] = useState("");
+  const { onChange, currency, value } = props;
+  const [textValue, setTextValue] = useState(value || "");
   const handleOnChange = ({ target }) => {
+    console.log(`Received new target value ${target.value}`)
     let { groups } = /\$?(?<number>[\d,]*)?(?<decimal>\.\d{0,6})?/.exec(
       target.value
     );

--- a/src/Inputs/TokenSelect.js
+++ b/src/Inputs/TokenSelect.js
@@ -1,5 +1,6 @@
 import { default as React } from "react";
 import { Form } from "react-bootstrap";
+
 export default function TokenSelect(props) {
   const { onChange, token, tokens, nameProperty } = props;
   const handleTokenChange = (tokenId) => {

--- a/src/LiquidityBalances.js
+++ b/src/LiquidityBalances.js
@@ -1,6 +1,6 @@
 import { BASE_FACTOR } from "./constants";
 import { blockReward, formatPercentage, tokenName } from "./helpers";
-import { formatCurrency, formatTokenBalance } from "./helpers";
+import { excludeUsd, formatCurrency, formatTokenBalance } from "./helpers";
 import { sumBy } from "lodash";
 import { default as React } from "react";
 
@@ -35,7 +35,7 @@ export default function YourLiquidity(props) {
               </tr>
             </thead>
             <tbody>
-              {liquidityTokens.map((liquidityToken) => (
+              {excludeUsd(liquidityTokens).map((liquidityToken) => (
                 <tr key={liquidityToken.id}>
                   <th scope="row">{tokenName(liquidityToken)}</th>
                   <td className="text-right">

--- a/src/LiquidityBalances.js
+++ b/src/LiquidityBalances.js
@@ -1,9 +1,8 @@
+import { BASE_FACTOR } from "./constants";
 import { blockReward, formatPercentage, tokenName } from "./helpers";
 import { formatCurrency, formatTokenBalance } from "./helpers";
-
-import { BASE_FACTOR } from "./constants";
-import { default as React } from "react";
 import { sumBy } from "lodash";
+import { default as React } from "react";
 
 export default function YourLiquidity(props) {
   const { liquidityTokens, blockNumber } = props;

--- a/src/Loader.js
+++ b/src/Loader.js
@@ -1,7 +1,6 @@
-import { animated, useTransition } from "react-spring";
-
 import Logo from "./logo.svg";
 import React from "react";
+import { animated, useTransition } from "react-spring";
 
 export default function Loader(props) {
   const { loading } = props;

--- a/src/ManageLiquidity/ManageLiquidity.js
+++ b/src/ManageLiquidity/ManageLiquidity.js
@@ -2,6 +2,7 @@ import TokenAmountInput from "../Inputs/TokenAmountInput";
 import TokenSelect from "../Inputs/TokenSelect";
 import { BASE_FACTOR, TOKENS, LIQUIDITY_TOKENS } from "../constants";
 import {
+  excludeUsd,
   encodeToken,
   tokenToString,
   formatCurrency,
@@ -119,7 +120,7 @@ export default function ManageLiquidity(props) {
               <Form.Group className="basic">
                 <Form.Label>Token</Form.Label>
                 <TokenSelect
-                  tokens={LIQUIDITY_TOKENS}
+                  tokens={excludeUsd(LIQUIDITY_TOKENS)}
                   onChange={(token) => setProvideToken(token)}
                   token={provideToken}
                 />

--- a/src/ManageLiquidity/ManageLiquidity.js
+++ b/src/ManageLiquidity/ManageLiquidity.js
@@ -1,16 +1,16 @@
+import TokenAmountInput from "../Inputs/TokenAmountInput";
+import TokenSelect from "../Inputs/TokenSelect";
 import { BASE_FACTOR, TOKENS, LIQUIDITY_TOKENS } from "../constants";
-import { Button, Form, InputGroup, Tab, Tabs } from "react-bootstrap";
 import {
   encodeToken,
   tokenToString,
   formatCurrency,
   formatTokenBalance,
 } from "../helpers";
-import { ChevronLeft } from "react-feather";
-import { default as React, useMemo, useState } from "react";
-import TokenAmountInput from "../Inputs/TokenAmountInput";
-import TokenSelect from "../Inputs/TokenSelect";
 import { usePostTransaction } from "../mutations";
+import { default as React, useMemo, useState } from "react";
+import { Button, Form, InputGroup, Tab, Tabs } from "react-bootstrap";
+import { ChevronLeft } from "react-feather";
 
 export default function ManageLiquidity(props) {
   const { onHide, liquidityTokens } = props;

--- a/src/PendingTransactions.js
+++ b/src/PendingTransactions.js
@@ -1,8 +1,7 @@
-import { default as React, useEffect } from "react";
-
-import { ExternalLink } from "react-feather";
-import Spinner from "react-bootstrap/Spinner";
 import classNames from "classnames";
+import { default as React, useEffect } from "react";
+import Spinner from "react-bootstrap/Spinner";
+import { ExternalLink } from "react-feather";
 
 export default function PendingTransactions(props) {
   const { pendingTransactions, setPendingTransactions, ethBlockNumber } = props;

--- a/src/Rewards.js
+++ b/src/Rewards.js
@@ -1,8 +1,7 @@
 import { formatCurrency, formatTokenBalance } from "./helpers";
-
-import React from "react";
-import { useGetIssuanceRewards } from "./queries";
 import { usePostTransaction } from "./mutations";
+import { useGetIssuanceRewards } from "./queries";
+import React from "react";
 
 export default function Rewards(props) {
   const { totalLockedValue } = props;

--- a/src/Send.js
+++ b/src/Send.js
@@ -1,10 +1,9 @@
 import { BASE_FACTOR, TOKENS } from "./constants";
-import { Button, Form, Modal } from "react-bootstrap";
-
-import React from "react";
-import base64url from "base64url";
 import { tokenToString } from "./helpers";
 import { usePostTransaction } from "./mutations";
+import base64url from "base64url";
+import React from "react";
+import { Button, Form, Modal } from "react-bootstrap";
 
 export default function Send(props) {
   const { show, setShow, setHost } = props;

--- a/src/Sidebar.js
+++ b/src/Sidebar.js
@@ -1,9 +1,9 @@
-import { Download, Upload, X } from "react-feather";
-import Identicon from "react-identicons";
-import { Modal } from "react-bootstrap";
-import React from "react";
 import base64url from "base64url";
 import { saveAs } from "file-saver";
+import React from "react";
+import { Modal } from "react-bootstrap";
+import { Download, Upload, X } from "react-feather";
+import Identicon from "react-identicons";
 
 export default function Sidebar(props) {
   let {

--- a/src/Total.js
+++ b/src/Total.js
@@ -1,5 +1,5 @@
-import React from "react";
 import { formatCurrency } from "./helpers";
+import React from "react";
 
 export default function Total(props) {
   const { total } = props;

--- a/src/UnlockEllipticoin.js
+++ b/src/UnlockEllipticoin.js
@@ -1,10 +1,9 @@
+import base64url from "base64url";
+import copy from "copy-to-clipboard";
 import React, { useEffect } from "react";
-
 import Button from "react-bootstrap/Button";
 import Card from "react-bootstrap/Card";
 import Table from "react-bootstrap/Table";
-import base64url from "base64url";
-import copy from "copy-to-clipboard";
 
 const bytesToNumber = (bytes) =>
   Number(new DataView(new Uint8Array(bytes).buffer).getBigUint64(0, true));

--- a/src/YourAddress.js
+++ b/src/YourAddress.js
@@ -1,7 +1,7 @@
-import { Clipboard } from "react-feather";
-import React from "react";
 import base64url from "base64url";
 import copy from "copy-to-clipboard";
+import React from "react";
+import { Clipboard } from "react-feather";
 
 export default function YourAddress(props) {
   const { publicKey } = props;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
-import { BigInt } from "jsbi";
 import base64url from "base64url";
+import { BigInt } from "jsbi";
+
 export const BASE_FACTOR = BigInt(1000000);
 export const BLOCKS_PER_ERA = 8000000;
 export const NUMBER_OF_ERAS = 8;

--- a/src/ethereum-utils.js
+++ b/src/ethereum-utils.js
@@ -1,5 +1,6 @@
-import Web3 from "web3";
 import { promisify } from "es6-promisify";
+import Web3 from "web3";
+
 export async function getAccounts() {
   return window.web3.eth.getAccounts();
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -88,6 +88,22 @@ export function formatCurrency(amount) {
     .replace(/^(\D+)/, "$1 ");
 }
 
+export function formatTokenAmount(amount, maxPlaces = 10, sigFigs = 3) {
+  if (!amount) return 0;
+
+  if (amount - Math.floor(amount) === 0) {
+    const figs = amount.toString().length;
+    return figs >= sigFigs ? amount : amount.toFixed(sigFigs - figs);
+  }
+  let places = 0;
+  let tempAmount = amount;
+  while (tempAmount < 1) {
+    tempAmount *= 10;
+    places++;
+  }
+  return amount.toFixed(places === 0 ? 2 : Math.min(maxPlaces, places + sigFigs - 1));
+}
+
 export function tokenName(token) {
   return get(
     find(

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -116,6 +116,10 @@ export function tokenName(token) {
   );
 }
 
+export function excludeUsd(liquidityTokens) {
+  return liquidityTokens.filter(t => tokenName(t) !== "USD");
+}
+
 export function encodeAddress(address) {
   if (typeof address === "string") {
     return {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,14 +6,13 @@ import {
   NUMBER_OF_ERAS,
   NETWORK_ID,
 } from "./constants";
-import { find, get } from "lodash";
-
-import { BigInt } from "jsbi";
 import Ed25519Signer from "./cose/Ed25519Signer";
 import cbor from "cbor";
 import ethers from "ethers";
-import nacl from "tweetnacl";
+import { BigInt } from "jsbi";
+import { find, get } from "lodash";
 import { useState } from "react";
+import nacl from "tweetnacl";
 
 export function parseUnits(value, units) {
   try {
@@ -88,7 +87,7 @@ export function formatCurrency(amount) {
     .replace(/^(\D+)/, "$1 ");
 }
 
-export function formatTokenAmount(amount, maxPlaces = 10, sigFigs = 3) {
+export function formatTokenExchangeRate(amount, maxPlaces = 10, sigFigs = 6) {
   if (!amount) return 0;
 
   if (amount - Math.floor(amount) === 0) {
@@ -101,7 +100,9 @@ export function formatTokenAmount(amount, maxPlaces = 10, sigFigs = 3) {
     tempAmount *= 10;
     places++;
   }
-  return amount.toFixed(places === 0 ? 2 : Math.min(maxPlaces, places + sigFigs - 1));
+  return amount.toFixed(
+    places === 0 ? 2 : Math.min(maxPlaces, places + sigFigs - 1)
+  );
 }
 
 export function tokenName(token) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import "./styles/style.scss";
 import ApolloWrapper from "./ApolloWrapper";
+import "./styles/style.scss";
 import React from "react";
 import ReactDOM from "react-dom";
 

--- a/src/mutations.js
+++ b/src/mutations.js
@@ -1,12 +1,11 @@
-import { gql, useMutation } from "@apollo/client";
-import { signTransaction, useLocalStorage } from "./helpers";
-import { useContext, useMemo } from "react";
-
 import CurrentMinerContext from "./CurrentMinerContext";
 import HostContext from "./HostContext";
-import cbor from "cbor";
-import nacl from "tweetnacl";
+import { signTransaction, useLocalStorage } from "./helpers";
 import { useGetNextNonce } from "./queries";
+import { gql, useMutation } from "@apollo/client";
+import cbor from "cbor";
+import { useContext, useMemo } from "react";
+import nacl from "tweetnacl";
 
 const POST_TRASACTION = gql`
   mutation($transaction: Bytes!) {

--- a/src/queries.js
+++ b/src/queries.js
@@ -1,9 +1,8 @@
 import { LIQUIDITY_TOKENS, TOKENS } from "./constants.js";
-import { gql, useQuery } from "@apollo/client";
-
-import nacl from "tweetnacl";
 import { useLocalStorage } from "./helpers";
+import { gql, useQuery } from "@apollo/client";
 import { useMemo } from "react";
+import nacl from "tweetnacl";
 
 export const GET_TOKENS = gql`
   query tokens($tokenIds: [TokenId!]!, $address: Bytes!) {


### PR DESCRIPTION
Front-end changes for adding a cap on slippage such that a trade will not go through if max slippage amount is exceeded.

Also in this PR
* Adding Exchange Rate to Exchange view
* Adding Available Liquidity to Exchange view
* Fixing trade calculations and output display, especially when output token is not USD
* Fees to include 2x fees when going non-base token to non-base token