### PR TITLE
Update liquidity rewards display

### DIFF
--- a/src/LiquidityBalances.js
+++ b/src/LiquidityBalances.js
@@ -1,5 +1,5 @@
 import Rewards from "./Rewards";
-import { BASE_FACTOR, USD, MS, TOKEN_METADATA } from "./constants";
+import { BASE_FACTOR, USD, TOKEN_METADATA } from "./constants";
 import CompoundContext from "./CompoundContext";
 import { formatPercentage, value, tokenTicker } from "./helpers";
 import { sumBy } from "lodash";
@@ -92,7 +92,6 @@ export default function LiquidityBalances(props) {
                         <RewardPerBlock
                           liquidityToken={liquidityToken}
                           blockNumber={blockNumber}
-                          MS={MS}
                         />
                       </td>
                       <td className="text-right no-padding-bottom">

--- a/src/LiquidityBalances.js
+++ b/src/LiquidityBalances.js
@@ -6,6 +6,7 @@ import { sumBy } from "lodash";
 import { Button } from "react-bootstrap";
 import { Fragment } from "react";
 import RewardPerBlock from "./RewardPerBlock";
+import TokenIssuancePerBlock from "./TokenIssuancePerBlock";
 
 export default function LiquidityBalances(props) {
   const {
@@ -68,8 +69,11 @@ export default function LiquidityBalances(props) {
               <tr>
                 <th scope="col">Token</th>
                 <th scope="col" className="text-right">
-                  Your Share of Pool (MS Issuance for Token Pool Per Block) = MS
-                  per Block
+                  MS Issuance per Block
+                </th>
+
+                <th scope="col" className="text-right">
+                  Your Percentage of Pool (MS per Block)
                 </th>
                 <th scope="col" className="text-right">
                   Tokens In Pool
@@ -88,6 +92,12 @@ export default function LiquidityBalances(props) {
                       <th scope="row" rowSpan="2">
                         {TOKEN_METADATA[liquidityToken.tokenAddress].name}
                       </th>
+                      <td className="text-right" rowSpan="2">
+                        <TokenIssuancePerBlock
+                          liquidityToken={liquidityToken}
+                          blockNumber={blockNumber}
+                        />
+                      </td>
                       <td className="text-right" rowSpan="2">
                         <RewardPerBlock
                           liquidityToken={liquidityToken}

--- a/src/LiquidityBalances.js
+++ b/src/LiquidityBalances.js
@@ -4,8 +4,8 @@ import CompoundContext from "./CompoundContext";
 import { Percentage, formatPercentage, value, tokenTicker } from "./helpers";
 import { sumBy } from "lodash";
 import { Button } from "react-bootstrap";
-import { blockReward } from "ellipticoin";
 import { Fragment } from "react";
+import RewardPerBlock from "./RewardPerBlock";
 
 export default function LiquidityBalances(props) {
   const {
@@ -68,7 +68,8 @@ export default function LiquidityBalances(props) {
               <tr>
                 <th scope="col">Token</th>
                 <th scope="col" className="text-right">
-                  Share of Pool (MS Issuance Per Block)
+                  Your Share of Pool (MS Issuance for Token Pool Per Block) = MS
+                  per Block
                 </th>
                 <th scope="col" className="text-right">
                   Tokens In Pool
@@ -90,21 +91,13 @@ export default function LiquidityBalances(props) {
                       <td className="text-right" rowSpan="2">
                         <Percentage
                           numerator={liquidityToken.balance}
-                          denomiator={liquidityToken.totalSupply}
+                          denominator={liquidityToken.totalSupply}
                         />
-                        {liquidityToken.totalSupply &&
-                        blockReward(blockNumber, liquidityToken.tokenAddress)
-                          ? ` (${value(
-                              (liquidityToken.poolSupplyOfToken *
-                                blockReward(
-                                  blockNumber,
-                                  liquidityToken.tokenAddress
-                                )) /
-                                liquidityToken.totalSupply,
-                              MS.address,
-                              { showCurrency: true, zeroString: "N/A" }
-                            )})`
-                          : null}
+                        <RewardPerBlock
+                          liquidityToken={liquidityToken}
+                          blockNumber={blockNumber}
+                          MS={MS}
+                        />
                       </td>
                       <td className="text-right no-padding-bottom">
                         {value(

--- a/src/LiquidityBalances.js
+++ b/src/LiquidityBalances.js
@@ -1,7 +1,7 @@
 import Rewards from "./Rewards";
 import { BASE_FACTOR, USD, MS, TOKEN_METADATA } from "./constants";
 import CompoundContext from "./CompoundContext";
-import { Percentage, formatPercentage, value, tokenTicker } from "./helpers";
+import { formatPercentage, value, tokenTicker } from "./helpers";
 import { sumBy } from "lodash";
 import { Button } from "react-bootstrap";
 import { Fragment } from "react";
@@ -89,10 +89,6 @@ export default function LiquidityBalances(props) {
                         {TOKEN_METADATA[liquidityToken.tokenAddress].name}
                       </th>
                       <td className="text-right" rowSpan="2">
-                        <Percentage
-                          numerator={liquidityToken.balance}
-                          denominator={liquidityToken.totalSupply}
-                        />
                         <RewardPerBlock
                           liquidityToken={liquidityToken}
                           blockNumber={blockNumber}

--- a/src/RewardPerBlock.js
+++ b/src/RewardPerBlock.js
@@ -1,25 +1,25 @@
-import { value } from "./helpers";
+import { Percentage, value } from "./helpers";
 import { blockReward } from "ellipticoin";
 import { BASE_FACTOR } from "./constants";
 export default function RewardPerBlock({ liquidityToken, blockNumber, MS }) {
-  const numerator = liquidityToken.balance;
-  const denominator = liquidityToken.totalSupply;
-  const percentage = Number(numerator * 100n) / Number(denominator);
+  const yourPercentageOfIssuance =
+    Number(liquidityToken.balance) / Number(liquidityToken.totalSupply);
+  const tokenIssuance = blockReward(blockNumber, liquidityToken.tokenAddress);
 
-  const issuanceNumerator =
-    liquidityToken.poolSupplyOfToken *
-    blockReward(blockNumber, liquidityToken.tokenAddress);
-  const issuance = issuanceNumerator / liquidityToken.totalSupply;
   const yourIssuance = (
-    (Number(issuance) * percentage) /
+    (Number(tokenIssuance) * yourPercentageOfIssuance) /
     Number(BASE_FACTOR)
   ).toFixed(6);
 
   return (
     <>
+      <Percentage
+        numerator={liquidityToken.balance}
+        denominator={liquidityToken.totalSupply}
+      />
       {liquidityToken.totalSupply &&
       blockReward(blockNumber, liquidityToken.tokenAddress)
-        ? ` (${value(issuance, MS.address, {
+        ? ` (${value(tokenIssuance, MS.address, {
             showCurrency: true,
             zeroString: "N/A",
           })}) = ${yourIssuance} MS`

--- a/src/RewardPerBlock.js
+++ b/src/RewardPerBlock.js
@@ -1,7 +1,8 @@
 import { Percentage, value } from "./helpers";
 import { blockReward } from "ellipticoin";
 import { BASE_FACTOR } from "./constants";
-export default function RewardPerBlock({ liquidityToken, blockNumber, MS }) {
+import { MS } from "./constants";
+export default function RewardPerBlock({ liquidityToken, blockNumber }) {
   const yourPercentageOfIssuance =
     Number(liquidityToken.balance) / Number(liquidityToken.totalSupply);
   const tokenIssuance = blockReward(blockNumber, liquidityToken.tokenAddress);

--- a/src/RewardPerBlock.js
+++ b/src/RewardPerBlock.js
@@ -1,0 +1,29 @@
+import { value } from "./helpers";
+import { blockReward } from "ellipticoin";
+import { BASE_FACTOR } from "./constants";
+export default function RewardPerBlock({ liquidityToken, blockNumber, MS }) {
+  const numerator = liquidityToken.balance;
+  const denominator = liquidityToken.totalSupply;
+  const percentage = Number(numerator * 100n) / Number(denominator);
+
+  const issuanceNumerator =
+    liquidityToken.poolSupplyOfToken *
+    blockReward(blockNumber, liquidityToken.tokenAddress);
+  const issuance = issuanceNumerator / liquidityToken.totalSupply;
+  const yourIssuance = (
+    (Number(issuance) * percentage) /
+    Number(BASE_FACTOR)
+  ).toFixed(6);
+
+  return (
+    <>
+      {liquidityToken.totalSupply &&
+      blockReward(blockNumber, liquidityToken.tokenAddress)
+        ? ` (${value(issuance, MS.address, {
+            showCurrency: true,
+            zeroString: "N/A",
+          })}) = ${yourIssuance} MS`
+        : null}
+    </>
+  );
+}

--- a/src/RewardPerBlock.js
+++ b/src/RewardPerBlock.js
@@ -1,7 +1,6 @@
-import { Percentage, value } from "./helpers";
+import { Percentage } from "./helpers";
 import { blockReward } from "ellipticoin";
 import { BASE_FACTOR } from "./constants";
-import { MS } from "./constants";
 export default function RewardPerBlock({ liquidityToken, blockNumber }) {
   const yourPercentageOfIssuance =
     Number(liquidityToken.balance) / Number(liquidityToken.totalSupply);
@@ -18,13 +17,7 @@ export default function RewardPerBlock({ liquidityToken, blockNumber }) {
         numerator={liquidityToken.balance}
         denominator={liquidityToken.totalSupply}
       />
-      {liquidityToken.totalSupply &&
-      blockReward(blockNumber, liquidityToken.tokenAddress)
-        ? ` (${value(tokenIssuance, MS.address, {
-            showCurrency: true,
-            zeroString: "N/A",
-          })}) = ${yourIssuance} MS`
-        : null}
+      {` (${yourIssuance} MS)`}
     </>
   );
 }

--- a/src/RewardPerBlock.js
+++ b/src/RewardPerBlock.js
@@ -1,15 +1,13 @@
 import { Percentage } from "./helpers";
 import { blockReward } from "ellipticoin";
-import { BASE_FACTOR } from "./constants";
-export default function RewardPerBlock({ liquidityToken, blockNumber }) {
-  const yourPercentageOfIssuance =
-    Number(liquidityToken.balance) / Number(liquidityToken.totalSupply);
-  const tokenIssuance = blockReward(blockNumber, liquidityToken.tokenAddress);
+import { value } from "./helpers";
+import { MS } from "./constants";
 
-  const yourIssuance = (
-    (Number(tokenIssuance) * yourPercentageOfIssuance) /
-    Number(BASE_FACTOR)
-  ).toFixed(6);
+export default function RewardPerBlock({ liquidityToken, blockNumber }) {
+  const yourIssuance =
+    (liquidityToken.balance *
+      blockReward(blockNumber, liquidityToken.tokenAddress)) /
+    liquidityToken.totalSupply;
 
   return (
     <>
@@ -17,7 +15,10 @@ export default function RewardPerBlock({ liquidityToken, blockNumber }) {
         numerator={liquidityToken.balance}
         denominator={liquidityToken.totalSupply}
       />
-      {` (${yourIssuance} MS)`}
+      {` (${value(yourIssuance, MS.address, {
+        showCurrency: true,
+        zeroString: "N/A",
+      })})`}
     </>
   );
 }

--- a/src/TokenIssuancePerBlock.js
+++ b/src/TokenIssuancePerBlock.js
@@ -1,0 +1,18 @@
+import { value } from "./helpers";
+import { blockReward } from "ellipticoin";
+import { MS } from "./constants";
+export default function RewardPerBlock({ liquidityToken, blockNumber }) {
+  const tokenIssuance = blockReward(blockNumber, liquidityToken.tokenAddress);
+
+  return (
+    <>
+      {liquidityToken.totalSupply &&
+      blockReward(blockNumber, liquidityToken.tokenAddress)
+        ? `${value(tokenIssuance, MS.address, {
+            showCurrency: true,
+            zeroString: "N/A",
+          })}`
+        : null}
+    </>
+  );
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -12,9 +12,9 @@ import {
 import { ethers } from "ethers";
 import { useState, useEffect, useContext } from "react";
 
-export function Percentage({ numerator, denomiator }) {
+export function Percentage({ numerator, denominator }) {
   if (numerator === 0n) return (0).toFixed(4);
-  return `${(Number(numerator * 100n) / Number(denomiator)).toFixed(4)}%`;
+  return `${(Number(numerator * 100n) / Number(denominator)).toFixed(4)}%`;
 }
 
 export function formatPercentage(n, options = { decimals: 4 }) {


### PR DESCRIPTION
Change Summary:
* refactor rewards per block into its own class
* add a mention of exactly how much MS per block you receive
    ** NOTE: THE AMOUNTS DON'T LOOK QUITE RIGHT. Close, but not exact.


<img width="1680" alt="Screen Shot 2021-04-26 at 3 14 36 PM" src="https://user-images.githubusercontent.com/36577398/116138011-4d7ecb00-a6a2-11eb-99ea-5480d23477ac.png">
